### PR TITLE
#2 fixed cleanLinkedIn bug - returns null if url is invalid

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,4 @@
+DB_HOST=127.0.0.1
+DB_USER=root
+DB_PASSWORD=Luka-duka11
+DB_DATABASE=etrain

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ client/dist/bundle.js
 .DS_Store
 .env
 package-lock.json
+database/seeders

--- a/client/src/components/AddUser.jsx
+++ b/client/src/components/AddUser.jsx
@@ -41,7 +41,7 @@ class AddUser extends React.Component {
     return (
       <div>
         <div>
-          <h3>Hmmmm looks like your not a pasager on the train yet?</h3>
+          <h3>Hmmmm looks like you're not a passanger on the train yet?</h3>
           Lets get you a ticket!
         </div>
         <form onSubmit={this.handleSubmit}>

--- a/client/src/helpers/helpers.jsx
+++ b/client/src/helpers/helpers.jsx
@@ -4,16 +4,24 @@ const cleanLinkedIn = (fullLink) => {
   let name = null;
   /// Try first matching to the https link
   // eslint-disable-next-line no-useless-escape
-  name = fullLink.match('https:\/\/www\.linkedin\.com\/in\/([a-zA-Z0123456789-]+)')[1];
-
-  // if blank try other www link
-  if (!name) {
-    // eslint-disable-next-line no-useless-escape
+  if(fullLink.match('https:\/\/www\.linkedin\.com\/in\/([a-zA-Z0123456789-]+)')) {
+    name = fullLink.match('https:\/\/www\.linkedin\.com\/in\/([a-zA-Z0123456789-]+)')[1];
+    console.log('first matched:', name)
+  } else if (fullLink.match('www\.linkedin\.com\/in\/([a-zA-Z0123456789-]+)')){
     name = fullLink.match('www\.linkedin\.com\/in\/([a-zA-Z0123456789-]+)')[1];
+    console.log('second matched:', name)
   }
+ 
   return(name)
 } // End cleanLinkedIn
 
 module.exports = {
   cleanLinkedIn: cleanLinkedIn
 }
+
+//https://www.linkedin.com/in/lexyk/ => lexyk
+
+//www.linkedin.com/in/lexyk/ => lexyk
+
+//www.neopets.com/lexyk/ OR anything else => null
+

--- a/client/src/helpers/test.js
+++ b/client/src/helpers/test.js
@@ -1,0 +1,5 @@
+const helpers = require('./helpers.jsx');
+
+var name = helpers.cleanLinkedIn('www.neopets.com/lexyk');
+
+console.log(name);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "license": "UNLICENSED",
   "dependencies": {
     "axios": "^0.18.1",
+    "dotenv": "^8.2.0",
     "jquery": "^3.3.1",
+    "mysql": "^2.18.1",
     "nodemon": "^2.0.7",
     "react": "^16.3.1",
     "react-dom": "^16.3.1"
@@ -23,8 +25,10 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "body-parser": "^1.18.3",
+    "css-loader": "^5.1.2",
     "express": "^4.16.3",
     "mongoose": "^5.1.2",
+    "style-loader": "^2.0.0",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.2"
   }


### PR DESCRIPTION
Responding to issue #2 

client/src/helpers/helpers.jsx

```
const cleanLinkedIn = (fullLink) => {
  let name = null;
  /// Try first matching to the https link
  // eslint-disable-next-line no-useless-escape
  const matchV1 = fullLink.match('https:\/\/www\.linkedin\.com\/in\/([a-zA-Z0123456789-]+)');
  const matchV2 = fullLink.match('www\.linkedin\.com\/in\/([a-zA-Z0123456789-]+)');

  if(matchV1) {
    name = matchV1[1];
    console.log('first matched:', name)
  } else if (matchV2){
    name = matchV2[1];
    console.log('second matched:', name)
  }
 
  return(name)
} // End cleanLinkedIn

module.exports = {
  cleanLinkedIn: cleanLinkedIn
}
```