### PR TITLE
Fixed Typo 

### DIFF
--- a/client/src/components/AddUser.jsx
+++ b/client/src/components/AddUser.jsx
@@ -10,7 +10,11 @@ class AddUser extends React.Component {
       firstName: '',
       lastName: '',
       linkedin: '',
-      cohort: ''
+      cohort: '',
+      newCohort: false,
+      juniorCohort: '',
+      startDateCohort: '',
+      notAsshole: false
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -19,14 +23,34 @@ class AddUser extends React.Component {
 
   }
 
-  CreateNewUser (linkedin, first_name, last_name, cohort_name, cb) {
+  CreateNewUser () {
     console.log('CreateNewUser');
 
-    api.createUser(linkedin, first_name, last_name, cohort_name, (err, data) => {
+    let linkedInName = helpers.cleanLinkedIn(this.state.linkedin);
+
+    api.createUser(linkedInName, this.state.firstName, this.state.lastName, this.state.cohort.toUpperCase(), (err, data) => {
       if (err) {
-        cb(err);
+        console.log(err);
       } else {
-        cb(null, data)
+
+        // if there is an alert, activate the new cohort fields,
+        // The new user has not been created.
+        if (data.hasOwnProperty('alert'))
+          this.setState({
+            newCohort: true
+          });
+
+        else {
+          api.getUserByLinkedIn(linkedInName, (err, data) => {
+            if (err) {
+              console.log(err);
+            } else {
+
+              this.props.setPersonData(data);
+
+            }
+          }) /// End getUserByLinkedIn
+      }
 
       }
     })
@@ -46,27 +70,30 @@ class AddUser extends React.Component {
   handleSubmit(event) {
     event.preventDefault();
 
-    let linkedInName = helpers.cleanLinkedIn(this.state.linkedin);
+    /// Check if we are adding a new cohort
 
-    this.CreateNewUser(linkedInName, this.state.firstName, this.state.lastName, this.state.cohort,(err, response) => {
+    if (this.state.newCohort & !this.state.notAsshole) {
+      api.createCohort(this.state.cohort.toUpperCase(), this.state.juniorCohort.toUpperCase(), this.state.startDateCohort, (err, data) => {
+        if (err) {
+          console.log(err);
+        } else {
 
-      if (err) {
-        console.log(err);
-      } else {
+            this.CreateNewUser()
 
-        api.getUserByLinkedIn(linkedInName, (err, data) => {
-          if (err) {
-            console.log(err);
-          } else {
+        }
+      })
 
-            this.props.setPersonData(data);
+    } else {
 
-          }
-        })
-      }
-    })
+      this.CreateNewUser()
+
+    }
+
 
   }
+
+
+
 
   render() {
     return (
@@ -92,6 +119,35 @@ class AddUser extends React.Component {
             Cohort:
             <input type="text" name="cohort" value={this.state.cohort} onChange={this.handleChange} />
           </label>
+
+          {this.state.newCohort &&
+          <div>
+            <div>
+              Hmmm I dont reconize that cohort name. Did you enter it correctly?
+              <br/>
+              If you are part of a cohort that is not yet in the system would you please give some additional details to help you and your peers out!
+              <br/>
+            </div>
+            <label>
+            Junior Cohort Name:
+            <input type="text" name="juniorCohort" value={this.state.juniorCohort} onChange={this.handleChange} />
+          </label>
+          <label>
+          Start Date:
+          <input type="text" name="startDateCohort" value={this.state.startDateCohort} onChange={this.handleChange} placeholder = 'yyyy-mm-dd'/>
+        </label>
+        <div>
+            Please dont use this feature to troll or provide bad infomation about your cohort's details. <br/>
+            The vision of this site is the make it as easy as possible for HackReactor students to grow their network and having accurate infomation is the first step.
+        </div>
+        <label>
+          I certify that I am Not An Asshole
+          <input
+            name="isAsshole" type="checkbox" value={this.state.notAsshole} onChange={this.handleInputChange} />
+
+        </label>
+        </div>
+          }
           <input type="submit" value="Submit" />
         </form>
       </div>

--- a/client/src/helpers/api.jsx
+++ b/client/src/helpers/api.jsx
@@ -137,6 +137,25 @@ const getEndorsedPersons = (person_id, cb) => {
 } // End getEndorsedPersons
 
 
+/// Get preformace Metrics
+const createCohort = (cohort_name, junior_name, start_date, cb) => {
+  // Set up request config
+
+  var config = {
+    method: 'post',
+    url: `/cohort/?name=${cohort_name}&junior_name=${junior_name}&start_date='${start_date}'`,
+    headers: { }
+  };
+
+  axios(config)
+  .then(function (response) {
+    cb(null, response.data)
+  })
+  .catch(function (error) {
+    cb(error);
+  });
+
+} // End getNonConnections
 
 module.exports = {
   getUserByLinkedIn: getUserByLinkedIn,
@@ -144,5 +163,6 @@ module.exports = {
   updateConnection: updateConnection,
   createUser: createUser,
   getPreformaceMetrics:getPreformaceMetrics,
-  getEndorsedPersons:getEndorsedPersons
+  getEndorsedPersons:getEndorsedPersons,
+  createCohort:createCohort
 }

--- a/database/controllers/cohort.js
+++ b/database/controllers/cohort.js
@@ -1,8 +1,107 @@
 
 const db = require('../index.js');
 
-const createCohort = (data, cb) => {
+const createCohort = (name, junior_name, start_date, cb) => {
   console.log('In createCohort');
+
+  let inputData = {name: junior_name};
+
+  /// get Junior_id if exisits
+  getCohortId(inputData, (err, data) => {
+
+    if (err) {
+      cb(err, null)
+    } else {
+
+      let juniorId = null;
+      // if data was returned save the id,
+      if (data.hasOwnProperty('cohort_id')) {
+        juniorId = data.cohort_id;
+
+      /// Insert the Cohort
+      insertCohort(name, juniorId, start_date, (err, data) => {
+        if (err) {
+          cb(err);
+        } else {
+          cb(null, data);
+        }
+
+      })
+
+      // if not create a cohort for the junior cohort
+      } else {
+         insertCohort(junior_name, null, null, (err, data) => {
+          if (err) {
+            cb(err);
+          } else {
+
+            juniorId = data.cohort_id;
+
+
+            /// Insert the Cohort
+            insertCohort(name, juniorId, start_date, (err, data) => {
+              if (err) {
+                cb(err);
+              } else {
+                console.log('heres your new linked cohort:')
+                console.log(data);
+                cb(null, data)
+              }
+
+            })
+
+          }
+
+        })
+
+
+      }  // End of if Else on Junior Exisiting
+
+    }
+
+  })  /// End get Junior COhort ID
+
+};
+
+
+const insertCohort = (name, junior_id, start_date, cb) => {
+  console.log('In insertCohort');
+
+  if (name === undefined) {
+    return;
+  }
+
+  let input_junior_id = junior_id === undefined | junior_id === null ? null : junior_id;
+
+  let input_start_date = start_date === undefined | junior_id === null ? null : `${start_date}`;
+
+  let cohort_query = `INSERT INTO cohort(cohort_name, junior_id, start_date)
+  VALUES ('${name}', ${input_junior_id}, ${input_start_date});`
+
+  db.query(cohort_query,  (error, results) => {
+    // error will be an Error if one occurred during the query
+    // results will contain the results of the query
+
+    if (error) {
+      cb(error, null)
+    } else {
+
+      /// Get the Id of the newly inserted row
+      getCohortId({name}, (err, results) => {
+        if (error) {
+          cb(error, null)
+        } else {
+
+          cb(null, results);
+        }
+
+      })
+
+    }
+
+  })
+
+
 };
 
 
@@ -12,8 +111,6 @@ const getCohortId = (data, cb) => {
   FROM cohort AS c
   LEFT JOIN cohort as c2 ON c.id = c2.junior_id
   WHERE c.cohort_name = '${data.name}'`
-
-
 
   db.query(cohort_query,  (error, results) => {
     // error will be an Error if one occurred during the query
@@ -26,11 +123,9 @@ const getCohortId = (data, cb) => {
       cb(null, {... results});
     }
 
-
   })
 
-
-}
+} // End getCohortId
 
 
 

--- a/database/controllers/connection.js
+++ b/database/controllers/connection.js
@@ -116,7 +116,7 @@ const getConnectionMetrics = (person_id, cohort_id, junior_id, cb) => {
 
 (SELECT COUNT(p.id)
   FROM people as p
-  WHERE p.cohort_id = ${junior_id}) as num_cohort_senior;`
+  WHERE p.cohort_id = ${junior_id}) as num_cohort_junior;`
 
 
 

--- a/server/index.js
+++ b/server/index.js
@@ -14,21 +14,24 @@ app.use(bodyParser.urlencoded({extended: true}));
 app.use(express.static(__dirname + '/../client/dist'));
 
 
-// app.use((req, res, next) => {
-//   const err = new Error('Not Found');
-//   err.status = 404;
-//   next(err);
-// });
-
-/// Cohort
-// app.post('/cohort/create', (req, res) => {
-//   console.log('In POST Cohort Create')
-
-// });
-
-/// Get a User by submitinga LinkedIn link
+/// Get a cohort
 app.get('/cohort', (req, res) => {
   Cohort.getCohortId(req.query, (err, data) => {
+
+    if (err) {
+      res.send (`An Error Occured ${err}`)
+    } else {
+      res.send(data)
+    }
+
+  });
+});
+
+/// Create a cohort and peer cohorts
+app.post('/cohort', (req, res) => {
+  console.log(req.query.name, req.query.junior_name)
+
+  Cohort.createCohort(req.query.name, req.query.junior_name, req.query.start_date, (err, data) => {
 
     if (err) {
       res.send (`An Error Occured ${err}`)
@@ -47,6 +50,16 @@ app.post('/person/create', (req, res) => {
 
   Cohort.getCohortId({name: userData.cohort_name}, (err, data) => {
 
+    /// Test if a cohort was returned
+
+    // If not, return a new cohort alert
+    if (Object.keys(data).length <= 0 ) {
+      res.send( {
+        'alert' : "New Cohort"
+      });
+
+    } else {
+    /// if ti was returned, prepare create person and the response
     userData['cohort_id'] = data.cohort_id;
     userData['junior_id'] = data.junior_id;
     userData['senior_id'] = data.senior_id;
@@ -61,6 +74,8 @@ app.post('/person/create', (req, res) => {
         })
       }
     });
+
+    } // End of If stament on if cohort exisits
   })
 
 });


### PR DESCRIPTION
fix 'num_cohort_senior' to be 'num_cohort_junior'
```
const getConnectionMetrics = (person_id, cohort_id, junior_id, cb) => {
  console.log('In getConnectionMetrics')

  let query = `SELECT
  ( SELECT COUNT(CASE WHEN c.status_name = 'endorsed' THEN 1 ELSE 0 END)
  FROM people as p
  LEFT JOIN etrain.connections as c ON p.id = c.person_id
  WHERE p.id = ${person_id} AND p.cohort_id = ${cohort_id}
  GROUP BY p.id) as num_endorsed_self,

(SELECT COUNT(p.id)
  FROM people as p
  WHERE p.cohort_id = ${cohort_id}) as num_cohort_self,

  ( SELECT COUNT(CASE WHEN c.status_name = 'endorsed' THEN 1 ELSE 0 END)
  FROM people as p
  LEFT JOIN etrain.connections as c ON p.id = c.person_id
  WHERE p.id = ${person_id} AND p.cohort_id = ${junior_id}
  GROUP BY p.id) as num_endorsed_junior,

(SELECT COUNT(p.id)
  FROM people as p
  WHERE p.cohort_id = ${junior_id}) as num_cohort_junior;`



```