### PR TITLE
#17 updated query to include a friend status

### DIFF
--- a/database/controllers/connection.js
+++ b/database/controllers/connection.js
@@ -141,6 +141,11 @@ const getConnectionMetrics = (person_id, cohort_id, junior_id, cb) => {
     if (err) {
       cb(err)
     }
+    console.log(results);
+    results[0]['num_endorsed_self'] = !results[0]['num_endorsed_self'] ? 0 : results[0]['num_endorsed_self'];
+
+    results[0]['num_endorsed_junior'] = !results[0]['num_endorsed_junior'] ? 0 : results[0]['num_endorsed_junior'];
+
     cb(null, results);
   });
 

--- a/database/controllers/connection.js
+++ b/database/controllers/connection.js
@@ -62,14 +62,31 @@ const getConnectedId = (id, target_id, cb) => {
 
 const getUnConnectedList = (id, cohort_id, cb) => {
     let person_query = `
-    SELECT p.id, p.first_name, p.last_name, p.linkedin, p.cohort_id, COUNT(c.person_id) as num_connections FROM etrain.people AS p
+    --  Select all the people who we dont have a connection with
+    SELECT p.id, p.first_name, p.last_name, p.linkedin, p.cohort_id, COUNT(c.person_id) as num_connections, 0 as friended FROM etrain.people AS p
     --     Get the connection data (is used for ordering)
         LEFT JOIN etrain.connections as c ON p.id = c.person_id
     -- Limit the results to the target person who are either not conencted at all or friended
     WHERE (
       p.id NOT IN (SELECT target_id FROM etrain.people as p
         INNER JOIN etrain.connections as c ON p.id = c.person_id
-        WHERE p.id = ${id}) OR
+        WHERE p.id = ${id})
+          )
+      AND p.cohort_id = ${cohort_id}
+      AND p.id != ${id}
+    --     Group the results by id for aggregating the num_connections
+        GROUP BY p.id
+
+
+    --  Now combine  with the people who are friended
+        UNION ALL
+
+
+        SELECT p.id, p.first_name, p.last_name, p.linkedin, p.cohort_id, COUNT(c.person_id) as num_connections, 1 as friended FROM etrain.people AS p
+    --     Get the connection data (is used for ordering)
+        LEFT JOIN etrain.connections as c ON p.id = c.person_id
+    -- Limit the results to the target person who are either not conencted at all or friended
+    WHERE (
           p.id IN (SELECT target_id FROM etrain.people as p
         INNER JOIN etrain.connections as c ON p.id = c.person_id
         WHERE p.id = ${id} and c.status_name = 'friended'


### PR DESCRIPTION
This branch is actually for #17 but I had a typo moment 


New Example response:
```
[
    {
        "id": 1,
        "first_name": "Molly",
        "last_name": "Fuhrman",
        "linkedin": "molly-fuhrman",
        "cohort_id": 2,
        "num_connections": 32,
        "friended": 0
    },
    {
        "id": 2,
        "first_name": "Mick",
        "last_name": "Annese",
        "linkedin": "mickannese",
        "cohort_id": 2,
        "num_connections": 6,
        "friended": 1
    },
    {
        "id": 32,
        "first_name": "Andy",
        "last_name": "Pham",
        "linkedin": "apham3x",
        "cohort_id": 2,
        "num_connections": 0,
        "friended": 1
    },
```
Where friended value 1 is true and 0 is false 